### PR TITLE
커뮤니티 모달에서 채팅 버튼을 눌렀을 때 setTimeout을 설정한다.

### DIFF
--- a/src/components/community/CommunityModal.tsx
+++ b/src/components/community/CommunityModal.tsx
@@ -51,7 +51,6 @@ const CommunityModal: FC<CommunityModalProps> = ({
   const ACCESS_TOKEN = sessionStorage.getItem("accessToken");
   const [commonList, setCommonList] = useRecoilState(commonListState);
   const navigate = useNavigate();
-  const $isMyData = ID === item.userId;
 
   //그룹 채팅 참여 버튼 클릭
   const handleClickChatButton = async () => {
@@ -73,16 +72,17 @@ const CommunityModal: FC<CommunityModalProps> = ({
       );
 
       if (response.status === 200) {
-        handleClosePostModal();
-        navigate(`/chat?chatId=${item.chatId}`);
+        setToastMsg("채팅방으로 이동합니다 ✈️");
+        setShowToastMsg(true);
       } else {
         console.log("그룹 채팅 참여하기 실패", response);
+        return;
       }
     } catch (error) {
       console.log(error);
       setToastMsg("이미 참여한 채팅입니다! 채팅방으로 이동합니다 ✈️");
       setShowToastMsg(true);
-
+    } finally {
       setTimeout(() => {
         setShowToastMsg(false);
         handleClosePostModal();
@@ -96,8 +96,8 @@ const CommunityModal: FC<CommunityModalProps> = ({
       await deleteData("community", id);
 
       // 삭제 완료 글 리스트 새로고침하기
-      const newList = commonList.filter((item) => {
-        return item.id !== ID;
+      const newList = commonList.filter((val) => {
+        return item.id !== val.id;
       });
       setCommonList(newList);
 
@@ -137,7 +137,7 @@ const CommunityModal: FC<CommunityModalProps> = ({
               <UserCard item={item} />
             </ModalLeft>
           )}
-          <ModalRight $isMyData>
+          <ModalRight>
             <h1>{item.title}</h1>
             <p>{item.content}</p>
             {ID !== item.userId && item.chatId !== "" && (
@@ -244,8 +244,8 @@ const ModalLeft = styled.div`
   }
 `;
 
-const ModalRight = styled.div<{ $isMyData?: boolean }>`
-  width: ${(props) => (props.$isMyData ? "100%" : "60%")};
+const ModalRight = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   gap: 1rem;

--- a/src/components/community/CommunityModal.tsx
+++ b/src/components/community/CommunityModal.tsx
@@ -51,6 +51,7 @@ const CommunityModal: FC<CommunityModalProps> = ({
   const ACCESS_TOKEN = sessionStorage.getItem("accessToken");
   const [commonList, setCommonList] = useRecoilState(commonListState);
   const navigate = useNavigate();
+  const $isMyData = ID === item.userId;
 
   //그룹 채팅 참여 버튼 클릭
   const handleClickChatButton = async () => {
@@ -136,32 +137,30 @@ const CommunityModal: FC<CommunityModalProps> = ({
               <UserCard item={item} />
             </ModalLeft>
           )}
-          <ModalRight>
+          <ModalRight $isMyData>
             <h1>{item.title}</h1>
             <p>{item.content}</p>
-            <div>
-              {ID !== item.userId && item.chatId !== "" && (
-                <GoToChatButton onClick={handleClickChatButton}>
-                  <img src={Chat} />
-                  그룹 채팅 참여
-                </GoToChatButton>
-              )}
+            {ID !== item.userId && item.chatId !== "" && (
+              <GoToChatButton onClick={handleClickChatButton}>
+                <img src={Chat} />
+                그룹 채팅 참여
+              </GoToChatButton>
+            )}
 
-              {ID === item.userId && (
-                <CommunityButtonWrapper>
-                  <AlertDialogModal item={item} handleDelete={handleDelete} />
-                  <Button
-                    variant="plain"
-                    color="primary"
-                    size="lg"
-                    sx={{ width: 1 / 2 }}
-                    onClick={handleUpdate}
-                  >
-                    수정
-                  </Button>
-                </CommunityButtonWrapper>
-              )}
-            </div>
+            {ID === item.userId && (
+              <CommunityButtonWrapper>
+                <AlertDialogModal item={item} handleDelete={handleDelete} />
+                <Button
+                  variant="plain"
+                  color="primary"
+                  size="lg"
+                  sx={{ width: 1 / 2 }}
+                  onClick={handleUpdate}
+                >
+                  수정
+                </Button>
+              </CommunityButtonWrapper>
+            )}
           </ModalRight>
         </ModalContent>
       </ModalWrapper>
@@ -245,7 +244,8 @@ const ModalLeft = styled.div`
   }
 `;
 
-const ModalRight = styled.div`
+const ModalRight = styled.div<{ $isMyData?: boolean }>`
+  width: ${(props) => (props.$isMyData ? "100%" : "60%")};
   display: flex;
   flex-direction: column;
   gap: 1rem;


### PR DESCRIPTION
## 📌 제목
커뮤니티 모달에서 채팅 버튼을 눌렀을 때 setTimeout을 설정한다.

## ✨ 작업 내용
커뮤니티 모달에서 채팅 버튼을 누르고 chatId를 사용해서 navigate시킬 때 setTimeout을 설정했습니다.
그 이유는 서버에서 채팅 정보를 가져오는 시간보다 url이 변경되는 시간이 더 빨라서
유저가 채팅방에 입장한 후 로딩하는 시간이 너무 길어서 서비스가 지연되다는 느낌을 덜 받게 하기 위함입니다.

서현님이 만드신 ToastMessage 사용해서 채팅방으로 이동하고 있음을 유저에게 알립니다.

### 유저가 참여하지 않은 새로운 채팅방으로 입장할 때

<img width="1710" alt="스크린샷 2023-11-16 오후 3 40 11" src="https://github.com/Toy2-Team3/sweety/assets/139190686/5a64820e-34f2-4076-876f-12f3426c4043">

### 유저가 이미 참여하고 있는 채팅방으로 입장할 때

<img width="1710" alt="스크린샷 2023-11-16 오후 3 39 45" src="https://github.com/Toy2-Team3/sweety/assets/139190686/090f25d2-924c-448e-8e85-036ffd98d619">

## ✅ 확인 사항
홈 컴포넌트에서도 동일하게 처리할 예정입니다.
