### PR TITLE
커뮤니티에서 탈퇴한 회원의 글을 보이지 않게 처리한다.

### DIFF
--- a/src/components/community/CommunityCreate.tsx
+++ b/src/components/community/CommunityCreate.tsx
@@ -141,7 +141,7 @@ const CommunityCreate = () => {
             <Button
               type="submit"
               variant="outlined"
-              color="primary"
+              color="danger"
               size="lg"
               sx={{ width: 1 / 2 }}
             >

--- a/src/pages/CommunityListPage.tsx
+++ b/src/pages/CommunityListPage.tsx
@@ -4,12 +4,10 @@ import CommunityItem from "../components/community/CommunityItem";
 import {
   CommunityData,
   IUserData,
-  getAllData,
   getAllDataOrderByDate,
   getOnlyActiveUser,
 } from "../utils/firebase";
 import { useNavigate } from "react-router-dom";
-import Button from "@mui/joy/Button";
 import { useRecoilState } from "recoil";
 import { commonListState } from "../recoil/atoms";
 import ToastMessage from "../components/common/ToastMessage";
@@ -67,14 +65,7 @@ const CommunityList = () => {
         <div>당신의 관심사를 공유해보세요</div>
       </Header>
       <AddButtonWrapper>
-        <Button
-          variant="solid"
-          color="danger"
-          size="lg"
-          onClick={handleCreateNewItem}
-        >
-          새 글 등록
-        </Button>
+        <AddButton onClick={handleCreateNewItem}>새 글 등록</AddButton>
       </AddButtonWrapper>
       <ItemWrapper>
         {commonList.map((item) => {
@@ -145,4 +136,21 @@ const ItemWrapper = styled.div`
   display: flex;
   flex-direction: column;
   gap: 2rem;
+`;
+
+const AddButton = styled.button`
+  background-color: ${(props) => props.theme.color.primary};
+  font-size: 1rem;
+  font-weight: 500;
+  color: white;
+
+  padding: 0.7rem 2rem;
+  border: none;
+  border-radius: 0.5rem;
+  transition: all 0.3s;
+
+  &:hover {
+    transform: scale(1.05);
+    cursor: pointer;
+  }
 `;

--- a/src/pages/CommunityListPage.tsx
+++ b/src/pages/CommunityListPage.tsx
@@ -6,6 +6,7 @@ import {
   IUserData,
   getAllData,
   getAllDataOrderByDate,
+  getOnlyActiveUser,
 } from "../utils/firebase";
 import { useNavigate } from "react-router-dom";
 import Button from "@mui/joy/Button";
@@ -32,7 +33,7 @@ const CommunityList = () => {
   };
 
   const fetchUserData = async () => {
-    const response = await getAllData("user");
+    const response = await getOnlyActiveUser();
     setUserList(response);
   };
 

--- a/src/utils/firebase.ts
+++ b/src/utils/firebase.ts
@@ -271,21 +271,32 @@ export const get = async (
 // 미아페이지 유저 데이터 업데이트
 export const updateUserData = async (
   userId: string,
-  props: MypageUserData
+  props: MypageUserData,
 ): Promise<void> => {
   const docRef = doc(db, "user", userId);
 
   await updateDoc(docRef, props);
-}; 
+};
 
 export const urlToBlob = async (tempImage: string) => {
-  try{
+  try {
     const response = await fetch(tempImage);
     const blob = await response.blob();
     const blobURL = URL.createObjectURL(blob);
     return blobURL;
-
   } catch (error) {
     console.error("Error loading image:", error);
   }
-}
+};
+
+export const getOnlyActiveUser = async () => {
+  const docRef = collection(db, "user");
+  const q = query(docRef, where("status", "==", "A"));
+  const userList: IUserData[] = [];
+  const querySnapshot = await getDocs(q);
+
+  querySnapshot.forEach((doc) => {
+    userList.push({ ...doc.data() } as IUserData);
+  });
+  return userList;
+};


### PR DESCRIPTION
## 📌 제목
커뮤니티에서 탈퇴한 회원의 글을 보이지 않게 처리한다.

## ✨ 작업 내용

- 파이어베이스 user 테이블에서 status의 값이 A인 유저들의 글만 화면에 표시될 수 있도록 기능 수정하였습니다.
- 추가로 커뮤니티의 '새 글 등록' 버튼 배경색을 primary 컬러로 수정하였습니다.

## ✅ 확인 사항